### PR TITLE
fix: correct clone url

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ See the [accompanying blog post on the AWS Serverless Blog](https://aws.amazon.c
 Clone this repository:
 
 ```bash
-git clone git@github.com:aws-samples/serverless-pdf-chat.git
+git clone https://github.com/aws-samples/serverless-pdf-chat.git
 ```
 
 ### Amazon Bedrock setup


### PR DESCRIPTION
This will prevent the following error during clone:

```
❯ git clone git@github.com:aws-samples/serverless-pdf-chat.git

Cloning into 'serverless-pdf-chat'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights and the repository exists.
```

*Issue #, if available:*

*Description of changes:*
Fix git clone url

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
