### PR TITLE
Makes embedding model id available as parameter; Upgrade to Titan V2

### DIFF
--- a/backend/src/generate_embeddings/main.py
+++ b/backend/src/generate_embeddings/main.py
@@ -9,6 +9,7 @@ from langchain.vectorstores import FAISS
 
 DOCUMENT_TABLE = os.environ["DOCUMENT_TABLE"]
 BUCKET = os.environ["BUCKET"]
+EMBEDDING_MODEL_ID = os.environ["EMBEDDING_MODEL_ID"]
 
 s3 = boto3.client("s3")
 ddb = boto3.resource("dynamodb")
@@ -44,7 +45,7 @@ def lambda_handler(event, context):
     )
 
     embeddings = BedrockEmbeddings(
-        model_id="amazon.titan-embed-text-v1",
+        model_id=EMBEDDING_MODEL_ID,
         client=bedrock_runtime,
         region_name="us-east-1",
     )

--- a/backend/src/generate_response/main.py
+++ b/backend/src/generate_response/main.py
@@ -13,6 +13,7 @@ from langchain.chains import ConversationalRetrievalChain
 MEMORY_TABLE = os.environ["MEMORY_TABLE"]
 BUCKET = os.environ["BUCKET"]
 MODEL_ID = os.environ["MODEL_ID"]
+EMBEDDING_MODEL_ID = os.environ["EMBEDDING_MODEL_ID"]
 
 s3 = boto3.client("s3")
 logger = Logger()
@@ -25,7 +26,7 @@ def get_embeddings():
     )
 
     embeddings = BedrockEmbeddings(
-        model_id="amazon.titan-embed-text-v1",
+        model_id=EMBEDDING_MODEL_ID,
         client=bedrock_runtime,
         region_name="us-east-1",
     )

--- a/backend/template.yaml
+++ b/backend/template.yaml
@@ -30,6 +30,9 @@ Parameters:
   ModelId:
     Default: "anthropic.claude-3-sonnet-20240229-v1:0"
     Type: String
+  EmbeddingModelId:
+    Default: "amazon.titan-embed-text-v2:0"
+    Type: String
 
 Conditions:
   DeployToAmplifyHosting: !Equals
@@ -303,11 +306,12 @@ Resources:
             - Sid: "BedrockScopedAccess"
               Effect: "Allow"
               Action: "bedrock:InvokeModel"
-              Resource: "arn:aws:bedrock:*::foundation-model/amazon.titan-embed-text-v1"
+              Resource: !Sub "arn:aws:bedrock:*::foundation-model/${EmbeddingModelId}"
       Environment:
         Variables:
           DOCUMENT_TABLE: !Ref DocumentTable
           BUCKET: !Ref DocumentBucket
+          EMBEDDING_MODEL_ID: !Ref EmbeddingModelId
       Events:
         EmbeddingQueueEvent:
           Type: SQS
@@ -332,12 +336,13 @@ Resources:
               Action: "bedrock:InvokeModel"
               Resource:
                 - !Sub "arn:aws:bedrock:*::foundation-model/${ModelId}"
-                - "arn:aws:bedrock:*::foundation-model/amazon.titan-embed-text-v1"
+                - !Sub "arn:aws:bedrock:*::foundation-model/${EmbeddingModelId}"
       Environment:
         Variables:
           MEMORY_TABLE: !Ref MemoryTable
           BUCKET: !Ref DocumentBucket
           MODEL_ID: !Ref ModelId
+          EMBEDDING_MODEL_ID: !Ref EmbeddingModelId
       Events:
         Root:
           Type: Api


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR makes selecting the embedding model available as a parameter through SAM. It also upgrades the default model to Titan v2.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
